### PR TITLE
allow passing in libyaml cflags by env var

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -10,9 +10,11 @@ use std::env;
 fn main()
 {
     let dir_var = env::var("OUT_DIR").unwrap();
+    let compile_flags = env::var("LIBYAML_CFLAGS").unwrap_or("".to_string());
     let dir = path::Path::new(&dir_var).join("codegen");
     let out_file = dir.to_str().unwrap();
     Command::new("gcc").arg("src/codegen/type_size.c")
+                       .arg(&compile_flags)
                        .arg("-o")
                        .arg(out_file)
                        .status()


### PR DESCRIPTION
Heya, 

I'm just learning rust, so i'm not sure if this is the best way. On my system (OSX 10.10) the package manager homebrew installs libyaml under /usr/local/ 
which isn't picked up by the codegen compile so this just allows me to pass an env var to get it to compile.

```
LIBYAML_CFLAGS=-I/usr/local/include cargo build
```