### PR TITLE
Make YamlStandardData clonable

### DIFF
--- a/src/constructor.rs
+++ b/src/constructor.rs
@@ -21,7 +21,7 @@ pub trait YamlConstructor<T, E> {
     }
 }
 
-#[derive(PartialEq, Debug)]
+#[derive(PartialEq, Clone, Debug)]
 pub enum YamlStandardData {
     YamlInteger(isize),
     YamlFloat(f64),


### PR DESCRIPTION
I think YamlStandardData should be clonable.

Thanks to @durka42.