### PR TITLE
Allow libyaml 0.2 to pass tests, make build on architectures where it failed

### DIFF
--- a/src/codecs.rs
+++ b/src/codecs.rs
@@ -6,14 +6,15 @@ use std::slice;
 use std::str;
 use std::ptr;
 use std::ffi::CStr;
+use std::os::raw::c_char;
 
 pub fn decode_c_str(c_str: *const ffi::yaml_char_t) -> Option<String> {
     if c_str == ptr::null() {
         None
     } else {
         unsafe {
-            let i8_str = c_str as *const i8;
-            str::from_utf8(CStr::from_ptr(i8_str).to_bytes()).map(|s| s.to_string()).ok()
+            let c_char_str = c_str as *const c_char;
+            str::from_utf8(CStr::from_ptr(c_char_str).to_bytes()).map(|s| s.to_string()).ok()
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -81,13 +81,13 @@ mod test {
     #[test]
     fn test_version_string() {
         let vsn = super::version_string();
-        assert!("0.1.4".to_string() <= vsn && vsn < "0.2".to_string())
+        assert!("0.1.4".to_string() <= vsn && vsn < "0.3".to_string())
     }
 
     #[test]
     fn test_version() {
         let vsn = super::version();
-        assert!((0, 1, 4) <= vsn && vsn < (0, 2, 0))
+        assert!((0, 1, 4) <= vsn && vsn < (0, 3, 0))
     }
 
     #[test]


### PR DESCRIPTION
The first commit allows libyaml 0.2 to be used in addition to 0.1. This only affects the tests. As far as I can see, the libyaml 0.2 API is compatible to the degree that is used in this crate.

When working on Debian packaging, a small bug showed preventing builds on architectures which use u8 as c_char. https://buildd.debian.org/status/fetch.php?pkg=rust-yaml&arch=arm64&ver=0.3.0-1&stamp=1539200882&raw=0 shows one of the failed builds. This is fixed in the second commit.